### PR TITLE
Fix generic importer type mismatches

### DIFF
--- a/Assets/Editor/DataImporter/BaseDataImporter.cs
+++ b/Assets/Editor/DataImporter/BaseDataImporter.cs
@@ -148,7 +148,7 @@ public abstract class BaseDataImporter
     /// <summary>
     /// 使用反射，根据表头信息自动填充一个对象。
     /// </summary>
-    private void PopulateObject(CardData asset, DataRow row, List<ColumnInfo> headerInfo)
+    private void PopulateObject(GameAsset asset, DataRow row, List<ColumnInfo> headerInfo)
     {
         Type assetType = asset.GetType();
 

--- a/Assets/Editor/DataImporter/ImporterCache.cs
+++ b/Assets/Editor/DataImporter/ImporterCache.cs
@@ -52,12 +52,3 @@ public static class ImporterCache
         }
     }
 }
-
-/// <summary>
-/// 所有数据ScriptableObject的始祖类，用于让缓存可以通用。
-/// （这个类您应该已经有了，放在这里以确保代码完整性）
-/// </summary>
-public abstract class GameAsset : ScriptableObject
-{
-    public int UniqueID;
-}


### PR DESCRIPTION
## Summary
- allow the shared importer to populate any GameAsset instead of being tied to CardData
- remove the duplicate GameAsset definition from the editor cache so the runtime type is reused

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68df47ee6c2c832dbc6be7142b4101a0